### PR TITLE
Upgrade to PHP 8.4 / PHPUnit 11 + PHP 8.x refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: php
 
-sudo: false
-
 php:
-  - 7.1
+  - 8.2
+  - 8.3
+  - 8.4
 
 before_script:
-  - composer install -n
+  - composer install --no-interaction --prefer-dist
+
+script:
+  - vendor/bin/phpunit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# ddd-workshops
+
+## Project Overview
+
+A PHP workshop project demonstrating Domain-Driven Design (DDD) and CQRS patterns. The project implements a simple User management domain with registration, activation, enable/disable, password change, and unregistration use cases.
+
+## Architecture
+
+- **DDD** (Domain-Driven Design) with a layered architecture
+- **CQRS** (Command Query Responsibility Segregation)
+- **Event-driven** patterns (see `event-driven` branch)
+- **Event Sourcing** (see `event-sourcing` branch)
+
+## Directory Structure
+
+```
+src/
+├── Application/User/         # Application layer (UserService, Commands, Event Handlers)
+│   ├── Command/              # Command objects (RegisterUserCommand, etc.)
+│   └── Event/                # Domain event handlers
+├── DomainModel/User/         # Domain model (User entity, Value Objects, Events, Repository interface)
+│   ├── Event/                # Domain events
+│   ├── Exception/            # Domain exceptions
+│   └── Password/             # UserPassword value object
+├── Infrastructure/           # Infrastructure layer (InMemory implementations)
+│   └── User/                 # InMemoryUserRepository, InMemoryUserReadModelRepository
+├── ReadModel/User/           # Read model (UserDTO, UserReadModelRepository interface)
+└── SharedKernel/User/        # Shared kernel (UserId, interfaces, base exceptions)
+
+tests/
+├── Unit/                     # Unit tests (mock dependencies)
+│   ├── Application/User/     # UserService unit tests
+│   ├── DomainModel/User/     # Domain model unit tests
+│   └── Infrastructure/User/ # Repository unit tests
+└── Integration/              # Integration tests (real in-memory storage)
+    └── Application/User/     # UserService integration tests
+```
+
+## Environment
+
+- **PHP**: ^8.4
+- **PHPUnit**: ^11.0
+- **No external runtime dependencies** (uses in-memory storage for all tests)
+
+## Running Tests
+
+```bash
+# Install dependencies
+composer install
+
+# Run all tests
+vendor/bin/phpunit
+
+# Run only unit tests
+vendor/bin/phpunit --testsuite unit
+
+# Run only integration tests
+vendor/bin/phpunit --testsuite integration
+```
+
+## Coding Conventions
+
+- `declare(strict_types=1)` in every file
+- PSR-4 autoloading under `TSwiackiewicz\AwesomeApp` namespace
+- Constructor property promotion with `readonly` for immutable Value Objects and Commands
+- PHP 8 attributes for PHPUnit: `#[Test]`, `#[DataProvider]`, `#[CoversClass]`
+- Data provider methods must be `static`
+- No `@var`, `@param`, `@return` PHPDoc — use native PHP type declarations instead
+
+## Branches
+
+| Branch | Description |
+|--------|-------------|
+| `master` | Basic DDD/CQRS implementation |
+| `event-driven` | Event-driven variant with domain events |
+| `event-sourcing` | Event sourcing variant |

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,9 @@
         }
     },
     "require": {
-        "php": ">=7.1"
+        "php": "^8.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.1"
+        "phpunit/phpunit": "^11.0"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit backupGlobals               = "false"
-         backupStaticAttributes      = "false"
-         colors                      = "true"
-         convertErrorsToExceptions   = "true"
-         convertNoticesToExceptions  = "true"
-         convertWarningsToExceptions = "true"
-         processIsolation            = "false"
-         stopOnFailure               = "false"
-         syntaxCheck                 = "false"
-         bootstrap                   = "./tests/bootstrap.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="./tests/bootstrap.php"
+         failOnWarning="true"
+         failOnDeprecation="true"
 >
     <testsuites>
         <testsuite name="unit">
@@ -20,9 +19,9 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="false">
+    <source>
+        <include>
             <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 </phpunit>

--- a/src/Application/User/Command/ActivateUserCommand.php
+++ b/src/Application/User/Command/ActivateUserCommand.php
@@ -3,29 +3,12 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\Application\User\Command;
 
-/**
- * Class ActivateUserCommand
- * @package TSwiackiewicz\AwesomeApp\Application\User\Command
- */
 class ActivateUserCommand implements UserCommand
 {
-    /**
-     * @var string
-     */
-    private $hash;
-
-    /**
-     * ActivateUserCommand constructor.
-     * @param string $hash
-     */
-    public function __construct(string $hash)
+    public function __construct(private readonly string $hash)
     {
-        $this->hash = $hash;
     }
 
-    /**
-     * @return string
-     */
     public function getHash(): string
     {
         return $this->hash;

--- a/src/Application/User/Command/ChangePasswordCommand.php
+++ b/src/Application/User/Command/ChangePasswordCommand.php
@@ -6,47 +6,19 @@ namespace TSwiackiewicz\AwesomeApp\Application\User\Command;
 use TSwiackiewicz\AwesomeApp\DomainModel\User\Password\UserPassword;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\UserId;
 
-/**
- * Class ChangePasswordCommand
- * @package TSwiackiewicz\AwesomeApp\Application\User\Command
- */
 class ChangePasswordCommand implements UserCommand
 {
-    /**
-     * @var UserId
-     */
-    private $userId;
-
-    /**
-     * @var UserPassword
-     */
-    private $password;
-
-    /**
-     * ChangePasswordCommand constructor.
-     * @param UserId $userId
-     * @param UserPassword $password
-     */
     public function __construct(
-        UserId $userId,
-        UserPassword $password
-    )
-    {
-        $this->userId = $userId;
-        $this->password = $password;
+        private readonly UserId $userId,
+        private readonly UserPassword $password
+    ) {
     }
 
-    /**
-     * @return UserId
-     */
     public function getUserId(): UserId
     {
         return $this->userId;
     }
 
-    /**
-     * @return UserPassword
-     */
     public function getPassword(): UserPassword
     {
         return $this->password;

--- a/src/Application/User/Command/DisableUserCommand.php
+++ b/src/Application/User/Command/DisableUserCommand.php
@@ -5,29 +5,12 @@ namespace TSwiackiewicz\AwesomeApp\Application\User\Command;
 
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\UserId;
 
-/**
- * Class DisableUserCommand
- * @package TSwiackiewicz\AwesomeApp\Application\User\Command
- */
 class DisableUserCommand implements UserCommand
 {
-    /**
-     * @var UserId
-     */
-    private $userId;
-
-    /**
-     * DisableUserCommand constructor.
-     * @param UserId $userId
-     */
-    public function __construct(UserId $userId)
+    public function __construct(private readonly UserId $userId)
     {
-        $this->userId = $userId;
     }
 
-    /**
-     * @return UserId
-     */
     public function getUserId(): UserId
     {
         return $this->userId;

--- a/src/Application/User/Command/EnableUserCommand.php
+++ b/src/Application/User/Command/EnableUserCommand.php
@@ -5,29 +5,12 @@ namespace TSwiackiewicz\AwesomeApp\Application\User\Command;
 
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\UserId;
 
-/**
- * Class EnableUserCommand
- * @package TSwiackiewicz\AwesomeApp\Application\User\Command
- */
 class EnableUserCommand implements UserCommand
 {
-    /**
-     * @var UserId
-     */
-    private $userId;
-
-    /**
-     * EnableUserCommand constructor.
-     * @param UserId $userId
-     */
-    public function __construct(UserId $userId)
+    public function __construct(private readonly UserId $userId)
     {
-        $this->userId = $userId;
     }
 
-    /**
-     * @return UserId
-     */
     public function getUserId(): UserId
     {
         return $this->userId;

--- a/src/Application/User/Command/RegisterUserCommand.php
+++ b/src/Application/User/Command/RegisterUserCommand.php
@@ -7,44 +7,19 @@ use TSwiackiewicz\AwesomeApp\DomainModel\User\{
     Password\UserPassword, UserLogin
 };
 
-/**
- * Class RegisterUserCommand
- * @package TSwiackiewicz\AwesomeApp\Application\User\Command
- */
 class RegisterUserCommand implements UserCommand
 {
-    /**
-     * @var UserLogin
-     */
-    private $login;
-
-    /**
-     * @var UserPassword
-     */
-    private $password;
-
-    /**
-     * RegisterUserCommand constructor.
-     * @param UserLogin $login
-     * @param UserPassword $password
-     */
-    public function __construct(UserLogin $login, UserPassword $password)
-    {
-        $this->login = $login;
-        $this->password = $password;
+    public function __construct(
+        private readonly UserLogin $login,
+        private readonly UserPassword $password
+    ) {
     }
 
-    /**
-     * @return UserLogin
-     */
     public function getLogin(): UserLogin
     {
         return $this->login;
     }
 
-    /**
-     * @return UserPassword
-     */
     public function getPassword(): UserPassword
     {
         return $this->password;

--- a/src/Application/User/Command/UnregisterUserCommand.php
+++ b/src/Application/User/Command/UnregisterUserCommand.php
@@ -5,29 +5,12 @@ namespace TSwiackiewicz\AwesomeApp\Application\User\Command;
 
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\UserId;
 
-/**
- * Class UnregisterUserCommand
- * @package TSwiackiewicz\AwesomeApp\Application\User\Command
- */
 class UnregisterUserCommand implements UserCommand
 {
-    /**
-     * @var UserId
-     */
-    private $userId;
-
-    /**
-     * UnregisterUserCommand constructor.
-     * @param UserId $userId
-     */
-    public function __construct(UserId $userId)
+    public function __construct(private readonly UserId $userId)
     {
-        $this->userId = $userId;
     }
 
-    /**
-     * @return UserId
-     */
     public function getUserId(): UserId
     {
         return $this->userId;

--- a/src/Application/User/Command/UserCommand.php
+++ b/src/Application/User/Command/UserCommand.php
@@ -5,10 +5,7 @@ namespace TSwiackiewicz\AwesomeApp\Application\User\Command;
 
 /**
  * Marker interface for user's commands
- *
- * @package TSwiackiewicz\AwesomeApp\Application\User\Command
  */
 interface UserCommand
 {
-
 }

--- a/src/Application/User/CommandValidator.php
+++ b/src/Application/User/CommandValidator.php
@@ -6,14 +6,9 @@ namespace TSwiackiewicz\AwesomeApp\Application\User;
 use TSwiackiewicz\AwesomeApp\Application\User\Command\UserCommand;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\Exception\ValidationException;
 
-/**
- * Class CommandValidator
- * @package TSwiackiewicz\AwesomeApp\Application\User
- */
 class CommandValidator
 {
     /**
-     * @param UserCommand $command
      * @throws ValidationException
      */
     public function validate(UserCommand $command): void

--- a/src/Application/User/Event/UserActivatedEventHandler.php
+++ b/src/Application/User/Event/UserActivatedEventHandler.php
@@ -11,29 +11,12 @@ use TSwiackiewicz\DDD\Event\{
     Event, EventHandler
 };
 
-/**
- * Class UserActivatedEventHandler
- * @package TSwiackiewicz\AwesomeApp\Application\User\Event
- */
 class UserActivatedEventHandler implements EventHandler
 {
-    /**
-     * @var UserNotifier
-     */
-    private $notifier;
-
-    /**
-     * UserActivatedEventHandler constructor.
-     * @param UserNotifier $notifier
-     */
-    public function __construct(UserNotifier $notifier)
+    public function __construct(private readonly UserNotifier $notifier)
     {
-        $this->notifier = $notifier;
     }
 
-    /**
-     * @param Event $event
-     */
     public function handle(Event $event): void
     {
         if (!$event instanceof UserActivatedEvent) {

--- a/src/Application/User/Event/UserDisabledEventHandler.php
+++ b/src/Application/User/Event/UserDisabledEventHandler.php
@@ -11,29 +11,12 @@ use TSwiackiewicz\DDD\Event\{
     Event, EventHandler
 };
 
-/**
- * Class UserDisabledEventHandler
- * @package TSwiackiewicz\AwesomeApp\Application\User\Event
- */
 class UserDisabledEventHandler implements EventHandler
 {
-    /**
-     * @var UserNotifier
-     */
-    private $notifier;
-
-    /**
-     * UserDisabledEventHandler constructor.
-     * @param UserNotifier $notifier
-     */
-    public function __construct(UserNotifier $notifier)
+    public function __construct(private readonly UserNotifier $notifier)
     {
-        $this->notifier = $notifier;
     }
 
-    /**
-     * @param Event $event
-     */
     public function handle(Event $event): void
     {
         if (!$event instanceof UserDisabledEvent) {

--- a/src/Application/User/Event/UserEnabledEventHandler.php
+++ b/src/Application/User/Event/UserEnabledEventHandler.php
@@ -11,29 +11,12 @@ use TSwiackiewicz\DDD\Event\{
     Event, EventHandler
 };
 
-/**
- * Class UserEnabledEventHandler
- * @package TSwiackiewicz\AwesomeApp\Application\User\Event
- */
 class UserEnabledEventHandler implements EventHandler
 {
-    /**
-     * @var UserNotifier
-     */
-    private $notifier;
-
-    /**
-     * UserEnabledEventHandler constructor.
-     * @param UserNotifier $notifier
-     */
-    public function __construct(UserNotifier $notifier)
+    public function __construct(private readonly UserNotifier $notifier)
     {
-        $this->notifier = $notifier;
     }
 
-    /**
-     * @param Event $event
-     */
     public function handle(Event $event): void
     {
         if (!$event instanceof UserEnabledEvent) {

--- a/src/Application/User/Event/UserPasswordChangedEventHandler.php
+++ b/src/Application/User/Event/UserPasswordChangedEventHandler.php
@@ -11,29 +11,12 @@ use TSwiackiewicz\DDD\Event\{
     Event, EventHandler
 };
 
-/**
- * Class UserPasswordChangedEventHandler
- * @package TSwiackiewicz\AwesomeApp\Application\User\Event
- */
 class UserPasswordChangedEventHandler implements EventHandler
 {
-    /**
-     * @var UserNotifier
-     */
-    private $notifier;
-
-    /**
-     * UserPasswordChangedEventHandler constructor.
-     * @param UserNotifier $notifier
-     */
-    public function __construct(UserNotifier $notifier)
+    public function __construct(private readonly UserNotifier $notifier)
     {
-        $this->notifier = $notifier;
     }
 
-    /**
-     * @param Event $event
-     */
     public function handle(Event $event): void
     {
         if (!$event instanceof UserPasswordChangedEvent) {

--- a/src/Application/User/Event/UserRegisteredEventHandler.php
+++ b/src/Application/User/Event/UserRegisteredEventHandler.php
@@ -11,29 +11,12 @@ use TSwiackiewicz\DDD\Event\{
     Event, EventHandler
 };
 
-/**
- * Class UserRegisteredEventHandler
- * @package TSwiackiewicz\AwesomeApp\Application\User\Event
- */
 class UserRegisteredEventHandler implements EventHandler
 {
-    /**
-     * @var UserNotifier
-     */
-    private $notifier;
-
-    /**
-     * UserRegisteredEventHandler constructor.
-     * @param UserNotifier $notifier
-     */
-    public function __construct(UserNotifier $notifier)
+    public function __construct(private readonly UserNotifier $notifier)
     {
-        $this->notifier = $notifier;
     }
 
-    /**
-     * @param Event $event
-     */
     public function handle(Event $event): void
     {
         if (!$event instanceof UserRegisteredEvent) {

--- a/src/Application/User/Event/UserUnregisteredEventHandler.php
+++ b/src/Application/User/Event/UserUnregisteredEventHandler.php
@@ -11,29 +11,12 @@ use TSwiackiewicz\DDD\Event\{
     Event, EventHandler
 };
 
-/**
- * Class UserUnregisteredEventHandler
- * @package TSwiackiewicz\AwesomeApp\Application\User\Event
- */
 class UserUnregisteredEventHandler implements EventHandler
 {
-    /**
-     * @var UserNotifier
-     */
-    private $notifier;
-
-    /**
-     * UserUnregisteredEventHandler constructor.
-     * @param UserNotifier $notifier
-     */
-    public function __construct(UserNotifier $notifier)
+    public function __construct(private readonly UserNotifier $notifier)
     {
-        $this->notifier = $notifier;
     }
 
-    /**
-     * @param Event $event
-     */
     public function handle(Event $event): void
     {
         if (!$event instanceof UserUnregisteredEvent) {

--- a/src/Application/User/UserService.php
+++ b/src/Application/User/UserService.php
@@ -14,38 +14,17 @@ use TSwiackiewicz\AwesomeApp\SharedKernel\{
 };
 use TSwiackiewicz\DDD\Event\EventBus;
 
-/**
- * Class UserService
- * @package TSwiackiewicz\AwesomeApp\Application\User
- */
 class UserService
 {
-    /**
-     * @var UserRepository
-     */
-    private $repository;
-
-    /**
-     * @var UserPasswordService
-     */
-    private $passwordService;
-
-    /**
-     * UserService constructor.
-     * @param UserRepository $repository
-     * @param UserPasswordService $passwordService
-     */
-    public function __construct(UserRepository $repository, UserPasswordService $passwordService)
-    {
-        $this->repository = $repository;
-        $this->passwordService = $passwordService;
+    public function __construct(
+        private readonly UserRepository $repository,
+        private readonly UserPasswordService $passwordService
+    ) {
     }
 
     /**
      * Register new user
      *
-     * @param RegisterUserCommand $command
-     * @return UserId
      * @throws UserDomainModelException
      */
     public function register(RegisterUserCommand $command): UserId
@@ -76,7 +55,6 @@ class UserService
     /**
      * Activate user
      *
-     * @param ActivateUserCommand $command
      * @throws UserDomainModelException
      */
     public function activate(ActivateUserCommand $command): void
@@ -92,7 +70,6 @@ class UserService
     /**
      * Enable user
      *
-     * @param EnableUserCommand $command
      * @throws UserDomainModelException
      */
     public function enable(EnableUserCommand $command): void
@@ -108,7 +85,6 @@ class UserService
     /**
      * Disable user
      *
-     * @param DisableUserCommand $command
      * @throws UserDomainModelException
      */
     public function disable(DisableUserCommand $command): void
@@ -125,7 +101,6 @@ class UserService
      * Change user's password
      * Example usage of domain service (UserPasswordService)
      *
-     * @param ChangePasswordCommand $command
      * @throws UserDomainModelException
      * @throws ValidationException
      */
@@ -147,7 +122,6 @@ class UserService
      * Unregister user
      *
      * @see http://udidahan.com/2009/09/01/dont-delete-just-dont/
-     * @param UnregisterUserCommand $command
      * @throws UserDomainModelException
      */
     public function unregister(UnregisterUserCommand $command): void

--- a/src/DomainModel/User/Event/UserActivatedEvent.php
+++ b/src/DomainModel/User/Event/UserActivatedEvent.php
@@ -3,31 +3,18 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\DomainModel\User\Event;
 
-/**
- * Class UserActivatedEvent
- * @package TSwiackiewicz\AwesomeApp\DomainModel\User\Event
- */
 class UserActivatedEvent extends UserEvent
 {
-    /**
-     * @return bool
-     */
     public function isActive(): bool
     {
         return true;
     }
 
-    /**
-     * @return bool
-     */
     public function isEnabled(): bool
     {
         return true;
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return sprintf(

--- a/src/DomainModel/User/Event/UserDisabledEvent.php
+++ b/src/DomainModel/User/Event/UserDisabledEvent.php
@@ -3,23 +3,13 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\DomainModel\User\Event;
 
-/**
- * Class UserDisabledEvent
- * @package TSwiackiewicz\AwesomeApp\DomainModel\User\Event
- */
 class UserDisabledEvent extends UserEvent
 {
-    /**
-     * @return bool
-     */
     public function isEnabled(): bool
     {
         return false;
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return sprintf(

--- a/src/DomainModel/User/Event/UserEnabledEvent.php
+++ b/src/DomainModel/User/Event/UserEnabledEvent.php
@@ -3,23 +3,13 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\DomainModel\User\Event;
 
-/**
- * Class UserEnabledEvent
- * @package TSwiackiewicz\AwesomeApp\DomainModel\User\Event
- */
 class UserEnabledEvent extends UserEvent
 {
-    /**
-     * @return bool
-     */
     public function isEnabled(): bool
     {
         return true;
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return sprintf(

--- a/src/DomainModel/User/Event/UserEvent.php
+++ b/src/DomainModel/User/Event/UserEvent.php
@@ -6,44 +6,22 @@ namespace TSwiackiewicz\AwesomeApp\DomainModel\User\Event;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\UserId;
 use TSwiackiewicz\DDD\Event\Event;
 
-/**
- * Class UserEvent
- * @package TSwiackiewicz\AwesomeApp\DomainModel\User\Event
- */
 abstract class UserEvent implements Event
 {
-    /**
-     * @var UserId
-     */
-    protected $id;
+    protected readonly UserId $id;
+    protected readonly \DateTimeImmutable $occurredOn;
 
-    /**
-     * @var \DateTimeImmutable
-     */
-    protected $occurredOn;
-
-    /**
-     * UserEvent constructor.
-     * @param UserId $id
-     * @param null|\DateTimeImmutable $occurredOn
-     */
     public function __construct(UserId $id, ?\DateTimeImmutable $occurredOn = null)
     {
         $this->id = $id;
-        $this->occurredOn = $occurredOn ?: new \DateTimeImmutable();
+        $this->occurredOn = $occurredOn ?? new \DateTimeImmutable();
     }
 
-    /**
-     * @return UserId
-     */
     public function getId(): UserId
     {
         return $this->id;
     }
 
-    /**
-     * @return \DateTimeImmutable
-     */
     public function getOccurredOn(): \DateTimeImmutable
     {
         return $this->occurredOn;

--- a/src/DomainModel/User/Event/UserPasswordChangedEvent.php
+++ b/src/DomainModel/User/Event/UserPasswordChangedEvent.php
@@ -5,40 +5,21 @@ namespace TSwiackiewicz\AwesomeApp\DomainModel\User\Event;
 
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\UserId;
 
-/**
- * Class UserPasswordChangedEvent
- * @package TSwiackiewicz\AwesomeApp\DomainModel\User\Event
- */
 class UserPasswordChangedEvent extends UserEvent
 {
-    /**
-     * @var string
-     */
-    private $password;
-
-    /**
-     * UserPasswordChangedEvent constructor.
-     * @param UserId $id
-     * @param string $password
-     * @param \DateTimeImmutable|null $occurredOn
-     */
-    public function __construct(UserId $id, string $password, ?\DateTimeImmutable $occurredOn = null)
-    {
+    public function __construct(
+        UserId $id,
+        private readonly string $password,
+        ?\DateTimeImmutable $occurredOn = null
+    ) {
         parent::__construct($id, $occurredOn);
-        $this->password = $password;
     }
 
-    /**
-     * @return string
-     */
     public function getPassword(): string
     {
         return $this->password;
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return sprintf(

--- a/src/DomainModel/User/Event/UserRegisteredEvent.php
+++ b/src/DomainModel/User/Event/UserRegisteredEvent.php
@@ -5,55 +5,27 @@ namespace TSwiackiewicz\AwesomeApp\DomainModel\User\Event;
 
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\UserId;
 
-/**
- * Class UserRegisteredEvent
- * @package TSwiackiewicz\AwesomeApp\DomainModel\User\Event
- */
 class UserRegisteredEvent extends UserEvent
 {
-    /**
-     * @var string
-     */
-    private $login;
-
-    /**
-     * @var string
-     */
-    private $password;
-
-    /**
-     * UserRegisteredEvent constructor.
-     * @param UserId $id
-     * @param string $login
-     * @param string $password
-     * @param \DateTimeImmutable|null $occurredOn
-     */
-    public function __construct(UserId $id, string $login, string $password, ?\DateTimeImmutable $occurredOn = null)
-    {
+    public function __construct(
+        UserId $id,
+        private readonly string $login,
+        private readonly string $password,
+        ?\DateTimeImmutable $occurredOn = null
+    ) {
         parent::__construct($id, $occurredOn);
-        $this->login = $login;
-        $this->password = $password;
     }
 
-    /**
-     * @return string
-     */
     public function getLogin(): string
     {
         return $this->login;
     }
 
-    /**
-     * @return string
-     */
     public function getPassword(): string
     {
         return $this->password;
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return sprintf(

--- a/src/DomainModel/User/Event/UserUnregisteredEvent.php
+++ b/src/DomainModel/User/Event/UserUnregisteredEvent.php
@@ -3,31 +3,18 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\DomainModel\User\Event;
 
-/**
- * Class UserUnregisteredEvent
- * @package TSwiackiewicz\AwesomeApp\DomainModel\User\Event
- */
 class UserUnregisteredEvent extends UserEvent
 {
-    /**
-     * @return bool
-     */
     public function isActive(): bool
     {
         return false;
     }
 
-    /**
-     * @return bool
-     */
     public function isEnabled(): bool
     {
         return false;
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return sprintf(

--- a/src/DomainModel/User/Password/UserPassword.php
+++ b/src/DomainModel/User/Password/UserPassword.php
@@ -5,22 +5,13 @@ namespace TSwiackiewicz\AwesomeApp\DomainModel\User\Password;
 
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\Exception\InvalidArgumentException;
 
-/**
- * Class UserPassword
- * @package TSwiackiewicz\AwesomeApp\DomainModel\User\Password
- */
 class UserPassword
 {
     private const MIN_PASSWORD_LENGTH = 8;
 
-    /**
-     * @var string
-     */
-    private $password;
+    private readonly string $password;
 
     /**
-     * UserPassword constructor.
-     * @param string $password
      * @throws InvalidArgumentException
      */
     public function __construct(string $password)
@@ -31,7 +22,6 @@ class UserPassword
     }
 
     /**
-     * @param string $password
      * @throws InvalidArgumentException
      */
     private function assertPassword(string $password): void
@@ -43,26 +33,16 @@ class UserPassword
         // TODO: other password assertion rules
     }
 
-    /**
-     * @return string
-     */
     public function getPassword(): string
     {
         return $this->password;
     }
 
-    /**
-     * @param UserPassword $password
-     * @return bool
-     */
     public function equals(UserPassword $password): bool
     {
         return $this->password === (string)$password;
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return $this->password;

--- a/src/DomainModel/User/Password/UserPasswordService.php
+++ b/src/DomainModel/User/Password/UserPasswordService.php
@@ -6,27 +6,17 @@ namespace TSwiackiewicz\AwesomeApp\DomainModel\User\Password;
 /**
  * Example of domain service - responsible for strong password generation and
  * verification whether password is weak, strong or very strong
- *
- * @package TSwiackiewicz\AwesomeApp\DomainModel\User\Password
  */
 class UserPasswordService
 {
     private const STRONG_PASSWORD_THRESHOLD = 20;
     private const VERY_STRONG_PASSWORD_THRESHOLD = 40;
 
-    /**
-     * @param string $password
-     * @return bool
-     */
     public function isWeak(string $password): bool
     {
         return $this->calculatePasswordStrength($password) < self::STRONG_PASSWORD_THRESHOLD;
     }
 
-    /**
-     * @param string $password
-     * @return int
-     */
     private function calculatePasswordStrength(string $password): int
     {
         $strength = 0;
@@ -68,27 +58,16 @@ class UserPasswordService
         return $strength;
     }
 
-    /**
-     * @param string $password
-     * @return bool
-     */
     public function isStrong(string $password): bool
     {
         return $this->calculatePasswordStrength($password) >= self::STRONG_PASSWORD_THRESHOLD;
     }
 
-    /**
-     * @param string $password
-     * @return bool
-     */
     public function isVeryStrong(string $password): bool
     {
         return $this->calculatePasswordStrength($password) >= self::VERY_STRONG_PASSWORD_THRESHOLD;
     }
 
-    /**
-     * @return string
-     */
     public function generateStrongPassword(): string
     {
         // this is only sample generated strong password,

--- a/src/DomainModel/User/User.php
+++ b/src/DomainModel/User/User.php
@@ -9,57 +9,18 @@ use TSwiackiewicz\AwesomeApp\DomainModel\User\Password\UserPassword;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\Exception\InvalidArgumentException;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\UserId;
 
-/**
- * Class User
- * @package TSwiackiewicz\AwesomeApp\DomainModel\User
- */
 class User
 {
-    /**
-     * @var UserId
-     */
-    private $id;
-
-    /**
-     * @var UserLogin
-     */
-    private $login;
-
-    /**
-     * @var UserPassword
-     */
-    private $password;
-
-    /**
-     * @var bool
-     */
-    private $active;
-
-    /**
-     * @var bool
-     */
-    private $enabled;
-
-    /**
-     * User constructor.
-     * @param UserId $id
-     * @param UserLogin $login
-     * @param UserPassword $password
-     * @param bool $active
-     * @param bool $enabled
-     */
-    public function __construct(UserId $id, UserLogin $login, UserPassword $password, bool $active, bool $enabled)
-    {
-        $this->id = $id;
-        $this->login = $login;
-        $this->password = $password;
-        $this->active = $active;
-        $this->enabled = $enabled;
+    public function __construct(
+        private UserId $id,
+        private UserLogin $login,
+        private UserPassword $password,
+        private bool $active,
+        private bool $enabled
+    ) {
     }
 
     /**
-     * @param array $user
-     * @return User
      * @throws InvalidArgumentException
      */
     public static function fromNative(array $user): User
@@ -75,11 +36,6 @@ class User
 
     /**
      * Register new user
-     *
-     * @param UserId $id
-     * @param UserLogin $username
-     * @param UserPassword $password
-     * @return User
      */
     public static function register(UserId $id, UserLogin $username, UserPassword $password): User
     {
@@ -132,7 +88,6 @@ class User
     /**
      * Change user's password
      *
-     * @param UserPassword $password
      * @throws UserException
      * @throws PasswordException
      */
@@ -149,41 +104,26 @@ class User
         $this->password = $password;
     }
 
-    /**
-     * @return UserId
-     */
     public function getId(): UserId
     {
         return $this->id;
     }
 
-    /**
-     * @return UserLogin
-     */
     public function getLogin(): UserLogin
     {
         return $this->login;
     }
 
-    /**
-     * @return UserPassword
-     */
     public function getPassword(): UserPassword
     {
         return $this->password;
     }
 
-    /**
-     * @return bool
-     */
     public function isActive(): bool
     {
         return $this->active;
     }
 
-    /**
-     * @return bool
-     */
     public function isEnabled(): bool
     {
         return $this->enabled;
@@ -191,8 +131,6 @@ class User
 
     /**
      * Generate user hash string
-     *
-     * @return string
      */
     public function hash(): string
     {

--- a/src/DomainModel/User/UserLogin.php
+++ b/src/DomainModel/User/UserLogin.php
@@ -9,19 +9,12 @@ use TSwiackiewicz\AwesomeApp\SharedKernel\User\Exception\InvalidArgumentExceptio
  * Example of Value Object, very convenient way for data validation
  * In this particular case, user login validation can be implemented
  * with command validator
- *
- * @package TSwiackiewicz\AwesomeApp\DomainModel\User
  */
 class UserLogin
 {
-    /**
-     * @var string
-     */
-    private $login;
+    private readonly string $login;
 
     /**
-     * UserLogin constructor.
-     * @param string $login
      * @throws InvalidArgumentException
      */
     public function __construct(string $login)
@@ -33,17 +26,11 @@ class UserLogin
         $this->login = $login;
     }
 
-    /**
-     * @return string
-     */
     public function getLogin(): string
     {
         return $this->login;
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return $this->login;

--- a/src/Infrastructure/InMemoryStorage.php
+++ b/src/Infrastructure/InMemoryStorage.php
@@ -6,39 +6,19 @@ namespace TSwiackiewicz\AwesomeApp\Infrastructure;
 use TSwiackiewicz\DDD\Query\Sort\NullSort;
 use TSwiackiewicz\DDD\Query\Sort\Sort;
 
-/**
- * Class InMemoryStorage
- * @package TSwiackiewicz\AwesomeApp\Infrastructure
- */
 class InMemoryStorage
 {
     const TYPE_USER = 'user';
 
-    /**
-     * @var array
-     */
-    private static $storage = [];
+    private static array $storage = [];
 
-    /**
-     * @var array
-     */
-    private static $nextIdentity = [];
+    private static array $nextIdentity = [];
 
-    /**
-     * @param string $type
-     * @param int $id
-     * @return array
-     */
     public static function fetchById(string $type, int $id): array
     {
         return self::$storage[$type][$id] ?? [];
     }
 
-    /**
-     * @param string $type
-     * @param null|Sort $sort
-     * @return array
-     */
     public static function fetchAll(string $type, ?Sort $sort = null): array
     {
         return self::sort(
@@ -47,11 +27,6 @@ class InMemoryStorage
         );
     }
 
-    /**
-     * @param array $records
-     * @param Sort $sort
-     * @return array
-     */
     private static function sort(array $records, Sort $sort): array
     {
         if ($sort instanceof NullSort) {
@@ -72,10 +47,6 @@ class InMemoryStorage
         return $sortedRecords;
     }
 
-    /**
-     * @param string $type
-     * @param array $item
-     */
     public static function save(string $type, array $item): void
     {
         $id = $item['id'] ?? self::nextIdentity($type);
@@ -86,10 +57,6 @@ class InMemoryStorage
         }
     }
 
-    /**
-     * @param string $type
-     * @return int
-     */
     public static function nextIdentity(string $type): int
     {
         if (!isset(self::$nextIdentity[$type])) {
@@ -99,10 +66,6 @@ class InMemoryStorage
         return self::$nextIdentity[$type]++;
     }
 
-    /**
-     * @param string $type
-     * @param int $id
-     */
     public static function removeById(string $type, int $id): void
     {
         if (isset(self::$storage[$type][$id])) {
@@ -110,9 +73,6 @@ class InMemoryStorage
         }
     }
 
-    /**
-     * @param string $type
-     */
     public static function clear(?string $type = null): void
     {
         if (null === $type) {

--- a/src/Infrastructure/User/InMemoryUserReadModelRepository.php
+++ b/src/Infrastructure/User/InMemoryUserReadModelRepository.php
@@ -12,16 +12,8 @@ use TSwiackiewicz\DDD\Query\{
     PaginatedResult, QueryContext, Sort\Sort
 };
 
-/**
- * Class InMemoryUserReadModelRepository
- * @package TSwiackiewicz\AwesomeApp\Infrastructure\User
- */
 class InMemoryUserReadModelRepository implements UserReadModelRepository
 {
-    /**
-     * @param UserId $id
-     * @return null|UserDTO
-     */
     public function findById(UserId $id): ?UserDTO
     {
         $users = $this->fetchAllUsers();
@@ -29,10 +21,6 @@ class InMemoryUserReadModelRepository implements UserReadModelRepository
         return $users[$id->getId()] ?? null;
     }
 
-    /**
-     * @param null|Sort $sort
-     * @return array
-     */
     private function fetchAllUsers(?Sort $sort = null): array
     {
         $users = InMemoryStorage::fetchAll(InMemoryStorage::TYPE_USER, $sort);
@@ -42,11 +30,6 @@ class InMemoryUserReadModelRepository implements UserReadModelRepository
         }, $users);
     }
 
-    /**
-     * @param UserQuery $query
-     * @param QueryContext $context
-     * @return PaginatedResult
-     */
     public function findByQuery(UserQuery $query, QueryContext $context): PaginatedResult
     {
         $users = $this->fetchAllUsers($context->getSort());
@@ -62,10 +45,6 @@ class InMemoryUserReadModelRepository implements UserReadModelRepository
         return PaginatedResult::withPagination($filteredUsers, $context->getPagination());
     }
 
-    /**
-     * @param QueryContext $context
-     * @return PaginatedResult
-     */
     public function getUsers(QueryContext $context): PaginatedResult
     {
         $users = $this->fetchAllUsers($context->getSort());

--- a/src/Infrastructure/User/InMemoryUserRepository.php
+++ b/src/Infrastructure/User/InMemoryUserRepository.php
@@ -11,29 +11,15 @@ use TSwiackiewicz\AwesomeApp\SharedKernel\User\{
     Exception\InvalidArgumentException, Exception\UserRepositoryException, UserId
 };
 
-/**
- * Class InMemoryUserRepository
- * @package TSwiackiewicz\AwesomeApp\Infrastructure\User
- */
 class InMemoryUserRepository implements UserRepository
 {
-    /**
-     * @var array
-     */
-    private static $identityMap = [];
+    private static array $identityMap = [];
 
-    /**
-     * @return UserId
-     */
     public function nextIdentity(): UserId
     {
         return UserId::nullInstance();
     }
 
-    /**
-     * @param string $login
-     * @return bool
-     */
     public function exists(string $login): bool
     {
         $users = InMemoryStorage::fetchAll(InMemoryStorage::TYPE_USER);
@@ -47,8 +33,6 @@ class InMemoryUserRepository implements UserRepository
     }
 
     /**
-     * @param UserId $id
-     * @return User
      * @throws UserRepositoryException
      * @throws UserNotFoundException
      */
@@ -73,8 +57,6 @@ class InMemoryUserRepository implements UserRepository
     }
 
     /**
-     * @param string $hash
-     * @return User
      * @throws UserRepositoryException
      * @throws UserNotFoundException
      */
@@ -97,8 +79,6 @@ class InMemoryUserRepository implements UserRepository
     }
 
     /**
-     * @param User $user
-     * @return UserId
      * @throws UserRepositoryException
      */
     public function save(User $user): UserId
@@ -129,9 +109,6 @@ class InMemoryUserRepository implements UserRepository
         }
     }
 
-    /**
-     * @param UserId $id
-     */
     public function remove(UserId $id): void
     {
         InMemoryStorage::removeById(InMemoryStorage::TYPE_USER, $id->getId());

--- a/src/Infrastructure/User/StdOutUserNotifier.php
+++ b/src/Infrastructure/User/StdOutUserNotifier.php
@@ -6,15 +6,8 @@ namespace TSwiackiewicz\AwesomeApp\Infrastructure\User;
 use TSwiackiewicz\AwesomeApp\DomainModel\User\Event\UserEvent;
 use TSwiackiewicz\AwesomeApp\DomainModel\User\UserNotifier;
 
-/**
- * Class StdOutUserNotifier
- * @package TSwiackiewicz\AwesomeApp\Infrastructure\User
- */
 class StdOutUserNotifier implements UserNotifier
 {
-    /**
-     * @param UserEvent $event
-     */
     public function notifyUser(UserEvent $event): void
     {
         print $event . PHP_EOL;

--- a/src/ReadModel/User/UserDTO.php
+++ b/src/ReadModel/User/UserDTO.php
@@ -3,59 +3,18 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\ReadModel\User;
 
-/**
- * Class UserDTO
- * @package TSwiackiewicz\AwesomeApp\ReadModel\User
- */
 class UserDTO
 {
-    /**
-     * @var int
-     */
-    private $id;
-
-    /**
-     * @var string
-     */
-    private $login;
-
-    /**
-     * @var string
-     */
-    private $password;
-
-    /**
-     * @var bool
-     */
-    private $active;
-
-    /**
-     * @var bool
-     */
-    private $enabled;
-
-    /**
-     * UserDTO constructor.
-     * @param int $id
-     * @param string $login
-     * @param string $password
-     * @param bool $active
-     * @param bool $enabled
-     */
-    public function __construct($id, $login, $password, $active, $enabled)
-    {
-        $this->id = $id;
-        $this->login = $login;
-        $this->password = $password;
-        $this->active = $active;
-        $this->enabled = $enabled;
+    public function __construct(
+        private readonly int $id,
+        private readonly string $login,
+        private readonly string $password,
+        private readonly bool $active,
+        private readonly bool $enabled
+    ) {
     }
 
-    /**
-     * @param array $user
-     * @return UserDTO
-     */
-    public static function fromArray(array $user) : UserDTO
+    public static function fromArray(array $user): UserDTO
     {
         return new static(
             $user['id'],
@@ -66,41 +25,26 @@ class UserDTO
         );
     }
 
-    /**
-     * @return int
-     */
     public function getId(): int
     {
         return $this->id;
     }
 
-    /**
-     * @return string
-     */
     public function getLogin(): string
     {
         return $this->login;
     }
 
-    /**
-     * @return string
-     */
     public function getPassword(): string
     {
         return $this->password;
     }
 
-    /**
-     * @return bool
-     */
     public function isActive(): bool
     {
         return $this->active;
     }
 
-    /**
-     * @return bool
-     */
     public function isEnabled(): bool
     {
         return $this->enabled;

--- a/src/ReadModel/User/UserQuery.php
+++ b/src/ReadModel/User/UserQuery.php
@@ -3,44 +3,19 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\ReadModel\User;
 
-/**
- * Class UserQuery
- * @package TSwiackiewicz\AwesomeApp\ReadModel\User
- */
 class UserQuery
 {
-    /**
-     * @var bool
-     */
-    private $active;
-
-    /**
-     * @var bool
-     */
-    private $enabled;
-
-    /**
-     * UserQuery constructor.
-     * @param bool $active
-     * @param bool $enabled
-     */
-    public function __construct(bool $active, bool $enabled)
-    {
-        $this->active = $active;
-        $this->enabled = $enabled;
+    public function __construct(
+        private readonly bool $active,
+        private readonly bool $enabled
+    ) {
     }
 
-    /**
-     * @return bool
-     */
     public function isActive(): bool
     {
         return $this->active;
     }
 
-    /**
-     * @return bool
-     */
     public function isEnabled(): bool
     {
         return $this->enabled;

--- a/src/ReadModel/User/UserReadModel.php
+++ b/src/ReadModel/User/UserReadModel.php
@@ -7,49 +7,22 @@ use TSwiackiewicz\AwesomeApp\SharedKernel\User\UserId;
 use TSwiackiewicz\DDD\Query\PaginatedResult;
 use TSwiackiewicz\DDD\Query\QueryContext;
 
-/**
- * Class UserReadModel
- * @package TSwiackiewicz\AwesomeApp\ReadModel\User
- */
 class UserReadModel
 {
-    /**
-     * @var UserReadModelRepository
-     */
-    private $repository;
-
-    /**
-     * UserReadModel constructor.
-     * @param UserReadModelRepository $repository
-     */
-    public function __construct(UserReadModelRepository $repository)
+    public function __construct(private readonly UserReadModelRepository $repository)
     {
-        $this->repository = $repository;
     }
 
-    /**
-     * @param UserId $id
-     * @return null|UserDTO
-     */
     public function findById(UserId $id): ?UserDTO
     {
         return $this->repository->findById($id);
     }
 
-    /**
-     * @param UserQuery $query
-     * @param null|QueryContext $context
-     * @return PaginatedResult
-     */
     public function findByQuery(UserQuery $query, ?QueryContext $context = null): PaginatedResult
     {
         return $this->repository->findByQuery($query, $context ?: new QueryContext());
     }
 
-    /**
-     * @param null|QueryContext $context
-     * @return PaginatedResult
-     */
     public function getUsers(?QueryContext $context = null): PaginatedResult
     {
         return $this->repository->getUsers($context ?: new QueryContext());

--- a/src/SharedKernel/User/UserId.php
+++ b/src/SharedKernel/User/UserId.php
@@ -6,36 +6,18 @@ namespace TSwiackiewicz\AwesomeApp\SharedKernel\User;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\Exception\InvalidArgumentException;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\Exception\RuntimeException;
 
-/**
- * Class UserId
- * @package TSwiackiewicz\AwesomeApp\SharedKernel\User
- */
 class UserId
 {
     private const NULL_ID = 0;
 
-    /**
-     * @var int
-     */
-    private $id;
-
-    /**
-     * UserId constructor.
-     * @param int $id
-     * @throws InvalidArgumentException
-     */
-    private function __construct(int $id)
+    private function __construct(private readonly int $id)
     {
         if ($id < 0) {
             throw new InvalidArgumentException('Not allowed ');
         }
-
-        $this->id = $id;
     }
 
     /**
-     * @param int $id
-     * @return UserId
      * @throws InvalidArgumentException
      */
     public static function fromInt(int $id): UserId
@@ -43,9 +25,6 @@ class UserId
         return new self($id);
     }
 
-    /**
-     * @return UserId
-     */
     public static function nullInstance(): UserId
     {
         try {
@@ -65,17 +44,11 @@ class UserId
         }
     }
 
-    /**
-     * @return bool
-     */
     public function isNull(): bool
     {
         return static::NULL_ID === $this->id;
     }
 
-    /**
-     * @return int
-     */
     public function getId(): int
     {
         return $this->id;

--- a/tests/Integration/Application/User/UserServiceBaseTestCase.php
+++ b/tests/Integration/Application/User/UserServiceBaseTestCase.php
@@ -19,40 +19,18 @@ use TSwiackiewicz\AwesomeApp\Infrastructure\{
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\UserId;
 use TSwiackiewicz\DDD\Event\EventBus;
 
-/**
- * Class UserServiceBaseTestCase
- * @package TSwiackiewicz\AwesomeApp\Tests\Integration\Application\User
- */
 abstract class UserServiceBaseTestCase extends TestCase
 {
-    /**
-     * @var int
-     */
-    protected $userId = 1;
+    protected int $userId = 1;
 
-    /**
-     * @var string
-     */
-    protected $login = 'test@domain.com';
+    protected string $login = 'test@domain.com';
 
-    /**
-     * @var string
-     */
-    protected $password = 'password1234';
+    protected string $password = 'password1234';
 
-    /**
-     * @var string
-     */
-    protected $hash = '94b3e2c871ff1b3e4e03c74cd9c501f5';
+    protected string $hash = '94b3e2c871ff1b3e4e03c74cd9c501f5';
 
-    /**
-     * @var UserService
-     */
-    protected $service;
+    protected UserService $service;
 
-    /**
-     * Disable user
-     */
     protected function disableUser(): void
     {
         $repository = new InMemoryUserRepository();
@@ -67,9 +45,6 @@ abstract class UserServiceBaseTestCase extends TestCase
         );
     }
 
-    /**
-     * Enable user
-     */
     protected function enableUser(): void
     {
         $repository = new InMemoryUserRepository();
@@ -84,9 +59,6 @@ abstract class UserServiceBaseTestCase extends TestCase
         );
     }
 
-    /**
-     * Setup fixtures
-     */
     protected function setUp(): void
     {
         $this->registerEventHandlers();
@@ -109,9 +81,6 @@ abstract class UserServiceBaseTestCase extends TestCase
         );
     }
 
-    /**
-     * Register event handlers
-     */
     private function registerEventHandlers(): void
     {
         EventBus::subscribe(
@@ -152,14 +121,10 @@ abstract class UserServiceBaseTestCase extends TestCase
         );
     }
 
-    /**
-     * Clear cache
-     */
     protected function clearCache(): void
     {
         InMemoryStorage::clear();
         $identityMap = new \ReflectionProperty(InMemoryUserRepository::class, 'identityMap');
-        $identityMap->setAccessible(true);
         $identityMap->setValue(null, []);
     }
 }

--- a/tests/Integration/Application/User/UserServiceTest.php
+++ b/tests/Integration/Application/User/UserServiceTest.php
@@ -3,9 +3,12 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\Tests\Integration\Application\User;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use TSwiackiewicz\AwesomeApp\Application\User\Command\{
     ActivateUserCommand, ChangePasswordCommand, DisableUserCommand, EnableUserCommand, RegisterUserCommand, UnregisterUserCommand
 };
+use TSwiackiewicz\AwesomeApp\Application\User\UserService;
 use TSwiackiewicz\AwesomeApp\DomainModel\User\{
     Exception\PasswordException, Exception\UserAlreadyExistsException, Exception\UserNotFoundException, Password\UserPassword, UserLogin
 };
@@ -15,17 +18,10 @@ use TSwiackiewicz\AwesomeApp\Infrastructure\{
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\Exception\InvalidArgumentException;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\UserId;
 
-/**
- * Class UserServiceTest
- * @package TSwiackiewicz\AwesomeApp\Tests\Integration\Application\User
- *
- * @coversDefaultClass UserService
- */
+#[CoversClass(UserService::class)]
 class UserServiceTest extends UserServiceBaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldRegisterUser(): void
     {
         $this->clearCache();
@@ -49,9 +45,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         self::assertEquals(UserId::fromInt($this->userId + 1), $nextRegisteredUserId);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenRegisteredUserAlreadyExists(): void
     {
         $this->expectException(UserAlreadyExistsException::class);
@@ -64,9 +58,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenRegisteredUserLoginIsInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -79,9 +71,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldActivateUser(): void
     {
         $this->service->activate(
@@ -94,9 +84,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         self::assertTrue($userDTO->isActive());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenActivatedUserNotExists(): void
     {
         $this->expectException(UserNotFoundException::class);
@@ -106,9 +94,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldEnableUser(): void
     {
         $this->disableUser();
@@ -123,9 +109,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         self::assertTrue($userDTO->isEnabled());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenEnabledUserNotExists(): void
     {
         $this->expectException(UserNotFoundException::class);
@@ -135,9 +119,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldDisableUser(): void
     {
         $this->enableUser();
@@ -152,9 +134,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         self::assertFalse($userDTO->isEnabled());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenDisabledUserNotExists(): void
     {
         $this->expectException(UserNotFoundException::class);
@@ -164,9 +144,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldChangePassword(): void
     {
         $this->enableUser();
@@ -185,9 +163,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         self::assertEquals($newPassword, $userDTO->getPassword());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenChangedPasswordIsTooWeak(): void
     {
         $this->enableUser();
@@ -202,9 +178,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenChangedPasswordEqualsWithCurrentPassword(): void
     {
         $this->enableUser();
@@ -219,9 +193,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenUserThatChangedPasswordNotExists(): void
     {
         $this->expectException(UserNotFoundException::class);
@@ -234,9 +206,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldRemoveUser(): void
     {
         $this->enableUser();
@@ -253,9 +223,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         self::assertNull($userDTO);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenRemovedUserNotExists(): void
     {
         $this->expectException(UserNotFoundException::class);

--- a/tests/Unit/Application/User/Event/UserActivatedEventHandlerTest.php
+++ b/tests/Unit/Application/User/Event/UserActivatedEventHandlerTest.php
@@ -3,21 +3,16 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\Tests\Unit\Application\User\Event;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use TSwiackiewicz\AwesomeApp\Application\User\Event\UserActivatedEventHandler;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\Exception\RuntimeException;
 use TSwiackiewicz\AwesomeApp\Tests\Unit\UserBaseTestCase;
 
-/**
- * Class UserActivatedEventHandlerTest
- * @package TSwiackiewicz\AwesomeApp\Tests\Unit\Application\User\Event
- *
- * @coversDefaultClass UserActivatedEventHandler
- */
+#[CoversClass(UserActivatedEventHandler::class)]
 class UserActivatedEventHandlerTest extends UserBaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenHandledEventIsInvalid(): void
     {
         $this->expectException(RuntimeException::class);

--- a/tests/Unit/Application/User/Event/UserDisabledEventHandlerTest.php
+++ b/tests/Unit/Application/User/Event/UserDisabledEventHandlerTest.php
@@ -3,21 +3,16 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\Tests\Unit\Application\User\Event;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use TSwiackiewicz\AwesomeApp\Application\User\Event\UserDisabledEventHandler;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\Exception\RuntimeException;
 use TSwiackiewicz\AwesomeApp\Tests\Unit\UserBaseTestCase;
 
-/**
- * Class UserDisabledEventHandlerTest
- * @package TSwiackiewicz\AwesomeApp\Tests\Unit\Application\User\Event
- *
- * @coversDefaultClass UserDisabledEventHandler
- */
+#[CoversClass(UserDisabledEventHandler::class)]
 class UserDisabledEventHandlerTest extends UserBaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenHandledEventIsInvalid(): void
     {
         $this->expectException(RuntimeException::class);

--- a/tests/Unit/Application/User/Event/UserEnabledEventHandlerTest.php
+++ b/tests/Unit/Application/User/Event/UserEnabledEventHandlerTest.php
@@ -3,21 +3,16 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\Tests\Unit\Application\User\Event;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use TSwiackiewicz\AwesomeApp\Application\User\Event\UserEnabledEventHandler;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\Exception\RuntimeException;
 use TSwiackiewicz\AwesomeApp\Tests\Unit\UserBaseTestCase;
 
-/**
- * Class UserEnabledEventHandlerTest
- * @package TSwiackiewicz\AwesomeApp\Tests\Unit\Application\User\Event
- *
- * @coversDefaultClass UserEnabledEventHandler
- */
+#[CoversClass(UserEnabledEventHandler::class)]
 class UserEnabledEventHandlerTest extends UserBaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenHandledEventIsInvalid(): void
     {
         $this->expectException(RuntimeException::class);

--- a/tests/Unit/Application/User/Event/UserPasswordChangedEventHandlerTest.php
+++ b/tests/Unit/Application/User/Event/UserPasswordChangedEventHandlerTest.php
@@ -3,21 +3,16 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\Tests\Unit\Application\User\Event;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use TSwiackiewicz\AwesomeApp\Application\User\Event\UserPasswordChangedEventHandler;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\Exception\RuntimeException;
 use TSwiackiewicz\AwesomeApp\Tests\Unit\UserBaseTestCase;
 
-/**
- * Class UserPasswordChangedEventHandlerTest
- * @package TSwiackiewicz\AwesomeApp\Tests\Unit\Application\User\Event
- *
- * @coversDefaultClass UserPasswordChangedEventHandler
- */
+#[CoversClass(UserPasswordChangedEventHandler::class)]
 class UserPasswordChangedEventHandlerTest extends UserBaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenHandledEventIsInvalid(): void
     {
         $this->expectException(RuntimeException::class);

--- a/tests/Unit/Application/User/Event/UserRegisteredEventHandlerTest.php
+++ b/tests/Unit/Application/User/Event/UserRegisteredEventHandlerTest.php
@@ -3,21 +3,16 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\Tests\Unit\Application\User\Event;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use TSwiackiewicz\AwesomeApp\Application\User\Event\UserRegisteredEventHandler;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\Exception\RuntimeException;
 use TSwiackiewicz\AwesomeApp\Tests\Unit\UserBaseTestCase;
 
-/**
- * Class UserRegisteredEventHandlerTest
- * @package TSwiackiewicz\AwesomeApp\Tests\Unit\Application\User\Event
- *
- * @coversDefaultClass UserRegisteredEventHandler
- */
+#[CoversClass(UserRegisteredEventHandler::class)]
 class UserRegisteredEventHandlerTest extends UserBaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenHandledEventIsInvalid(): void
     {
         $this->expectException(RuntimeException::class);

--- a/tests/Unit/Application/User/Event/UserUnregisteredEventHandlerTest.php
+++ b/tests/Unit/Application/User/Event/UserUnregisteredEventHandlerTest.php
@@ -3,21 +3,16 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\Tests\Unit\Application\User\Event;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use TSwiackiewicz\AwesomeApp\Application\User\Event\UserUnregisteredEventHandler;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\Exception\RuntimeException;
 use TSwiackiewicz\AwesomeApp\Tests\Unit\UserBaseTestCase;
 
-/**
- * Class UserUnregisteredEventHandlerTest
- * @package TSwiackiewicz\AwesomeApp\Tests\Unit\Application\User\Event
- *
- * @coversDefaultClass UserUnregisteredEventHandler
- */
+#[CoversClass(UserUnregisteredEventHandler::class)]
 class UserUnregisteredEventHandlerTest extends UserBaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenHandledEventIsInvalid(): void
     {
         $this->expectException(RuntimeException::class);

--- a/tests/Unit/Application/User/UserServiceBaseTestCase.php
+++ b/tests/Unit/Application/User/UserServiceBaseTestCase.php
@@ -11,26 +11,11 @@ use TSwiackiewicz\AwesomeApp\DomainModel\User\Password\UserPassword;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\UserId;
 use TSwiackiewicz\AwesomeApp\Tests\Unit\UserBaseTestCase;
 
-/**
- * Class UserServiceBaseTestCase
- * @package TSwiackiewicz\AwesomeApp\Tests\Unit\Application\User
- */
 abstract class UserServiceBaseTestCase extends UserBaseTestCase
 {
-    /**
-     * @return UserRepository
-     */
     protected function getUserRepositoryMockForRegisterUser(): UserRepository
     {
-        /** @var UserRepository|\PHPUnit_Framework_MockObject_MockObject $repository */
-        $repository = $this->getMockBuilder(UserRepository::class)
-            ->setMethods([
-                'nextIdentity',
-                'exists',
-                'save'
-            ])
-            ->disableOriginalConstructor()
-            ->getMockForAbstractClass();
+        $repository = $this->createMock(UserRepository::class);
         $repository->expects(self::once())->method('exists')->willReturn(false);
         $repository->expects(self::once())->method('nextIdentity')->willReturn(UserId::nullInstance());
         $repository->expects(self::once())->method('save');
@@ -38,49 +23,25 @@ abstract class UserServiceBaseTestCase extends UserBaseTestCase
         return $repository;
     }
 
-    /**
-     * @return UserRepository
-     */
     protected function getUserRepositoryMockWhenUserAlreadyExists(): UserRepository
     {
-        /** @var UserRepository|\PHPUnit_Framework_MockObject_MockObject $repository */
-        $repository = $this->getMockBuilder(UserRepository::class)
-            ->setMethods([
-                'exists'
-            ])
-            ->disableOriginalConstructor()
-            ->getMockForAbstractClass();
+        $repository = $this->createMock(UserRepository::class);
         $repository->expects(self::once())->method('exists')->willReturn(true);
 
         return $repository;
     }
 
-    /**
-     * @return UserRepository
-     */
     protected function getUserRepositoryMockForActivateUser(): UserRepository
     {
         $inactiveUser = $this->getUser(false, false);
 
-        /** @var UserRepository|\PHPUnit_Framework_MockObject_MockObject $repository */
-        $repository = $this->getMockBuilder(UserRepository::class)
-            ->setMethods([
-                'getByHash',
-                'save'
-            ])
-            ->disableOriginalConstructor()
-            ->getMockForAbstractClass();
+        $repository = $this->createMock(UserRepository::class);
         $repository->expects(self::once())->method('getByHash')->willReturn($inactiveUser);
         $repository->expects(self::once())->method('save');
 
         return $repository;
     }
 
-    /**
-     * @param bool $active
-     * @param bool $enabled
-     * @return User
-     */
     protected function getUser(bool $active, bool $enabled): User
     {
         return new User(
@@ -92,46 +53,22 @@ abstract class UserServiceBaseTestCase extends UserBaseTestCase
         );
     }
 
-    /**
-     * @return UserRepository|\PHPUnit_Framework_MockObject_MockObject
-     */
     protected function getUserRepositoryMock(): UserRepository
     {
-        return $this->getMockBuilder(UserRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(UserRepository::class);
     }
 
-    /**
-     * @param null|User $user
-     * @return UserRepository
-     */
     protected function getUserRepositoryMockReturningUser(?User $user = null): UserRepository
     {
-        /** @var UserRepository|\PHPUnit_Framework_MockObject_MockObject $repository */
-        $repository = $this->getMockBuilder(UserRepository::class)
-            ->setMethods([
-                'getById'
-            ])
-            ->disableOriginalConstructor()
-            ->getMockForAbstractClass();
+        $repository = $this->createMock(UserRepository::class);
         $repository->expects(self::once())->method('getById')->willReturn($user ?: $this->getUser(true, true));
 
         return $repository;
     }
 
-    /**
-     * @return UserRepository
-     */
     protected function getUserRepositoryMockWhenUserByHashNotFound(): UserRepository
     {
-        /** @var UserRepository|\PHPUnit_Framework_MockObject_MockObject $repository */
-        $repository = $this->getMockBuilder(UserRepository::class)
-            ->setMethods([
-                'getByHash'
-            ])
-            ->disableOriginalConstructor()
-            ->getMockForAbstractClass();
+        $repository = $this->createMock(UserRepository::class);
         $repository->expects(self::once())
             ->method('getByHash')
             ->willThrowException(UserNotFoundException::forUser($this->login));
@@ -139,18 +76,9 @@ abstract class UserServiceBaseTestCase extends UserBaseTestCase
         return $repository;
     }
 
-    /**
-     * @return UserRepository
-     */
     protected function getUserRepositoryMockWhenUserByIdNotFound(): UserRepository
     {
-        /** @var UserRepository|\PHPUnit_Framework_MockObject_MockObject $repository */
-        $repository = $this->getMockBuilder(UserRepository::class)
-            ->setMethods([
-                'getById'
-            ])
-            ->disableOriginalConstructor()
-            ->getMockForAbstractClass();
+        $repository = $this->createMock(UserRepository::class);
         $repository->expects(self::once())
             ->method('getById')
             ->willThrowException(UserNotFoundException::forUser($this->login));
@@ -158,27 +86,14 @@ abstract class UserServiceBaseTestCase extends UserBaseTestCase
         return $repository;
     }
 
-    /**
-     * @return UserPasswordService|\PHPUnit_Framework_MockObject_MockObject
-     */
     protected function getUserPasswordServiceMock(): UserPasswordService
     {
-        return $this->getMockBuilder(UserPasswordService::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(UserPasswordService::class);
     }
 
-    /**
-     * @return UserPasswordService|\PHPUnit_Framework_MockObject_MockObject
-     */
     protected function getUserPasswordServiceMockForWeakPasswordVerification(): UserPasswordService
     {
-        $service = $this->getMockBuilder(UserPasswordService::class)
-            ->disableOriginalConstructor()
-            ->setMethods([
-                'isWeak'
-            ])
-            ->getMock();
+        $service = $this->createMock(UserPasswordService::class);
         $service->expects(self::once())->method('isWeak')->willReturn(true);
 
         return $service;

--- a/tests/Unit/Application/User/UserServiceTest.php
+++ b/tests/Unit/Application/User/UserServiceTest.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\Tests\Unit\Application\User;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use TSwiackiewicz\AwesomeApp\Application\User\Command\ActivateUserCommand;
 use TSwiackiewicz\AwesomeApp\Application\User\Command\ChangePasswordCommand;
 use TSwiackiewicz\AwesomeApp\Application\User\Command\DisableUserCommand;
@@ -30,17 +32,10 @@ use TSwiackiewicz\AwesomeApp\DomainModel\User\UserLogin;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\UserId;
 use TSwiackiewicz\DDD\Event\EventBus;
 
-/**
- * Class UserService
- * @package TSwiackiewicz\AwesomeApp\Tests\Unit\Application\User
- *
- * @coversDefaultClass UserService
- */
+#[CoversClass(UserService::class)]
 class UserServiceTest extends UserServiceBaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldRegisterUser(): void
     {
         EventBus::subscribe(
@@ -59,9 +54,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenRegisteredUserAlreadyExists(): void
     {
         $this->expectException(UserAlreadyExistsException::class);
@@ -75,9 +68,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldActivateUser(): void
     {
         EventBus::subscribe(
@@ -96,9 +87,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenActivatedUserNotExists(): void
     {
         $this->expectException(UserNotFoundException::class);
@@ -112,9 +101,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldEnableUser(): void
     {
         $disabledUser = $this->getUser(true, false);
@@ -135,9 +122,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenEnabledUserNotExists(): void
     {
         $this->expectException(UserNotFoundException::class);
@@ -151,9 +136,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldDisableUser(): void
     {
         $enabledUser = $this->getUser(true, true);
@@ -174,9 +157,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenDisabledUserNotExists(): void
     {
         $this->expectException(UserNotFoundException::class);
@@ -190,9 +171,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldChangePassword(): void
     {
         $newPassword = 'new-VEEERY_StR0Ng_P@sSw0rD1!#';
@@ -217,9 +196,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenChangedPasswordIsTooWeak(): void
     {
         $this->expectException(PasswordException::class);
@@ -236,9 +213,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenUserChangingPasswordNotExists(): void
     {
         $this->expectException(UserNotFoundException::class);
@@ -255,9 +230,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldRemoveUser(): void
     {
         $enabledUser = $this->getUser(true, true);
@@ -278,9 +251,7 @@ class UserServiceTest extends UserServiceBaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenRemovedUserNotExists(): void
     {
         $this->expectException(UserNotFoundException::class);

--- a/tests/Unit/DomainModel/User/Password/UserPasswordServiceTest.php
+++ b/tests/Unit/DomainModel/User/Password/UserPasswordServiceTest.php
@@ -3,20 +3,15 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\Tests\Unit\DomainModel\User\Password;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use TSwiackiewicz\AwesomeApp\DomainModel\User\Password\UserPasswordService;
 use TSwiackiewicz\AwesomeApp\Tests\Unit\UserBaseTestCase;
 
-/**
- * Class UserPasswordServiceTest
- * @package TSwiackiewicz\AwesomeApp\Tests\Unit\DomainModel\User\Password
- *
- * @coversDefaultClass UserPasswordService
- */
+#[CoversClass(UserPasswordService::class)]
 class UserPasswordServiceTest extends UserBaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldCheckIfPasswordIsWeak(): void
     {
         $password = 'weak_password';
@@ -27,9 +22,7 @@ class UserPasswordServiceTest extends UserBaseTestCase
         self::assertFalse($service->isStrong($password));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldCheckIfPasswordIsStrong(): void
     {
         $password = 'StRoNg_PasSw0rD1';
@@ -41,9 +34,7 @@ class UserPasswordServiceTest extends UserBaseTestCase
         self::assertFalse($service->isVeryStrong($password));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldCheckIfPasswordIsVeryStrong(): void
     {
         $password = 'VEEERY_StR0Ng_P@sSw0rD1!#';
@@ -55,9 +46,7 @@ class UserPasswordServiceTest extends UserBaseTestCase
         self::assertTrue($service->isVeryStrong($password));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldGenerateStrongPassword(): void
     {
         $service = new UserPasswordService();

--- a/tests/Unit/DomainModel/User/Password/UserPasswordTest.php
+++ b/tests/Unit/DomainModel/User/Password/UserPasswordTest.php
@@ -3,21 +3,17 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\Tests\Unit\DomainModel\User\Password;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TSwiackiewicz\AwesomeApp\DomainModel\User\Password\UserPassword;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\Exception\InvalidArgumentException;
 use TSwiackiewicz\AwesomeApp\Tests\Unit\UserBaseTestCase;
 
-/**
- * Class UserPasswordTest
- * @package TSwiackiewicz\AwesomeApp\Tests\Unit\DomainModel\User\Password
- *
- * @coversDefaultClass UserPassword
- */
+#[CoversClass(UserPassword::class)]
 class UserPasswordTest extends UserBaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldCreateUserPassword(): void
     {
         $password = new UserPassword('password1234');
@@ -27,12 +23,8 @@ class UserPasswordTest extends UserBaseTestCase
         self::assertEquals('password1234', (string)$password);
     }
 
-    /**
-     * @test
-     * @dataProvider getInvalidPasswordDataProvider
-     *
-     * @param string $invalidPassword
-     */
+    #[Test]
+    #[DataProvider('getInvalidPasswordDataProvider')]
     public function shouldFailWhileCreationInvalidUserPassword(string $invalidPassword): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Unit/DomainModel/User/UserLoginTest.php
+++ b/tests/Unit/DomainModel/User/UserLoginTest.php
@@ -3,21 +3,17 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\Tests\Unit\DomainModel\User;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\Exception\InvalidArgumentException;
 use TSwiackiewicz\AwesomeApp\DomainModel\User\UserLogin;
 use TSwiackiewicz\AwesomeApp\Tests\Unit\UserBaseTestCase;
 
-/**
- * Class UserLoginTest
- * @package TSwiackiewicz\AwesomeApp\Tests\Unit\DomainModel\User
- *
- * @coversDefaultClass UserLogin
- */
+#[CoversClass(UserLogin::class)]
 class UserLoginTest extends UserBaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldCreateUserLogin(): void
     {
         $login = new UserLogin('test@domain.com');
@@ -27,12 +23,8 @@ class UserLoginTest extends UserBaseTestCase
         self::assertEquals('test@domain.com', (string)$login);
     }
 
-    /**
-     * @test
-     * @dataProvider getInvalidLoginDataProvider
-     *
-     * @param string $invalidLogin
-     */
+    #[Test]
+    #[DataProvider('getInvalidLoginDataProvider')]
     public function shouldFailWhileCreationInvalidUserLogin(string $invalidLogin): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Unit/DomainModel/User/UserTest.php
+++ b/tests/Unit/DomainModel/User/UserTest.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\Tests\Unit\DomainModel\User;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use TSwiackiewicz\AwesomeApp\DomainModel\User\Exception\PasswordException;
 use TSwiackiewicz\AwesomeApp\DomainModel\User\Exception\UserException;
 use TSwiackiewicz\AwesomeApp\DomainModel\User\Password\UserPassword;
@@ -11,17 +13,10 @@ use TSwiackiewicz\AwesomeApp\DomainModel\User\UserLogin;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\UserId;
 use TSwiackiewicz\AwesomeApp\Tests\Unit\UserBaseTestCase;
 
-/**
- * Class UserTest
- * @package TSwiackiewicz\AwesomeApp\Tests\Unit\DomainModel\User
- *
- * @coversDefaultClass User
- */
+#[CoversClass(User::class)]
 class UserTest extends UserBaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldRegisterUser(): void
     {
         $registeredUser = User::register(
@@ -38,9 +33,7 @@ class UserTest extends UserBaseTestCase
         self::assertEquals($this->hash, $registeredUser->hash());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldCreateFromNative(): void
     {
         $user = User::fromNative(
@@ -54,9 +47,7 @@ class UserTest extends UserBaseTestCase
         self::assertInstanceOf(User::class, $user);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldActivateUser(): void
     {
         $user = $this->createInactiveUser();
@@ -66,9 +57,7 @@ class UserTest extends UserBaseTestCase
         self::assertTrue($user->isEnabled());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenActivateAlreadyActivatedUser(): void
     {
         $this->expectException(UserException::class);
@@ -77,9 +66,7 @@ class UserTest extends UserBaseTestCase
         $user->activate();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldEnableUser(): void
     {
         $user = $this->createDisabledUser();
@@ -88,9 +75,7 @@ class UserTest extends UserBaseTestCase
         self::assertTrue($user->isEnabled());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenEnableInactiveUser(): void
     {
         $this->expectException(UserException::class);
@@ -99,9 +84,7 @@ class UserTest extends UserBaseTestCase
         $user->enable();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenEnableAlreadyEnabledUser(): void
     {
         $this->expectException(UserException::class);
@@ -110,9 +93,7 @@ class UserTest extends UserBaseTestCase
         $user->enable();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldDisableUser(): void
     {
         $user = $this->createEnabledUser();
@@ -121,9 +102,7 @@ class UserTest extends UserBaseTestCase
         self::assertFalse($user->isEnabled());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenDisableInactiveUser(): void
     {
         $this->expectException(UserException::class);
@@ -132,9 +111,7 @@ class UserTest extends UserBaseTestCase
         $user->disable();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenDisableAlreadyDisabledUser(): void
     {
         $this->expectException(UserException::class);
@@ -143,9 +120,7 @@ class UserTest extends UserBaseTestCase
         $user->disable();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldChangePassword(): void
     {
         $user = $this->createEnabledUser();
@@ -154,9 +129,7 @@ class UserTest extends UserBaseTestCase
         self::assertTrue($user->getPassword()->equals(new UserPassword('newPassword1234')));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenPasswordChangedByInactiveUser(): void
     {
         $this->expectException(UserException::class);
@@ -165,9 +138,7 @@ class UserTest extends UserBaseTestCase
         $user->changePassword(new UserPassword('newPassword1234'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenPasswordChangedByDisabledUser(): void
     {
         $this->expectException(UserException::class);
@@ -176,9 +147,7 @@ class UserTest extends UserBaseTestCase
         $user->changePassword(new UserPassword('newPassword1234'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenChangedPasswordEqualsWithCurrentPassword(): void
     {
         $this->expectException(PasswordException::class);

--- a/tests/Unit/Infrastructure/User/InMemoryUserReadModelRepositoryTest.php
+++ b/tests/Unit/Infrastructure/User/InMemoryUserReadModelRepositoryTest.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\Tests\Unit\Infrastructure\User;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TSwiackiewicz\AwesomeApp\Infrastructure\{
     InMemoryStorage, User\InMemoryUserReadModelRepository
 };
@@ -16,24 +19,14 @@ use TSwiackiewicz\DDD\Query\Pagination\Pagination;
 use TSwiackiewicz\DDD\Query\QueryContext;
 use TSwiackiewicz\DDD\Query\Sort\Sort;
 
-/**
- * Class InMemoryUserReadModelRepositoryTest
- * @package TSwiackiewicz\AwesomeApp\Tests\Unit\Infrastructure\User
- *
- * @@coversDefaultClass  InMemoryUserReadModelRepository
- */
+#[CoversClass(InMemoryUserReadModelRepository::class)]
 class InMemoryUserReadModelRepositoryTest extends UserBaseTestCase
 {
     private const USER_STORAGE_TYPE = 'user';
 
-    /**
-     * @var InMemoryUserReadModelRepository
-     */
-    private $repository;
+    private InMemoryUserReadModelRepository $repository;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFindUserById(): void
     {
         $user = $this->repository->findById(UserId::fromInt($this->userId));
@@ -41,9 +34,7 @@ class InMemoryUserReadModelRepositoryTest extends UserBaseTestCase
         self::assertInstanceOf(UserDTO::class, $user);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldReturnNullWhenUserNotFoundById(): void
     {
         $user = $this->repository->findById(UserId::fromInt(1234));
@@ -51,9 +42,7 @@ class InMemoryUserReadModelRepositoryTest extends UserBaseTestCase
         self::assertNull($user);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFindUsersByQuery(): void
     {
         $users = $this->repository->findByQuery(
@@ -65,9 +54,7 @@ class InMemoryUserReadModelRepositoryTest extends UserBaseTestCase
         self::assertInstanceOf(UserDTO::class, $users->getItems()[0]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldReturnEmptyArrayWhenUsersNotFoundByQuery(): void
     {
         $users = $this->repository->findByQuery(
@@ -78,9 +65,7 @@ class InMemoryUserReadModelRepositoryTest extends UserBaseTestCase
         self::assertEquals([], $users->getItems());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldReturnAllUsers(): void
     {
         $users = $this->repository->getUsers(new QueryContext());
@@ -91,14 +76,8 @@ class InMemoryUserReadModelRepositoryTest extends UserBaseTestCase
         }
     }
 
-    /**
-     * @test
-     * @dataProvider getQueryContextDataProvider
-     *
-     * @param QueryContext $context
-     * @param int $itemsCount
-     * @param int $totalItemsCount
-     */
+    #[Test]
+    #[DataProvider('getQueryContextDataProvider')]
     public function shouldReturnUsersWithQueryContext(
         QueryContext $context,
         int $itemsCount,
@@ -117,9 +96,7 @@ class InMemoryUserReadModelRepositoryTest extends UserBaseTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldReturnEmptyArrayWhenNoUsersDefined(): void
     {
         InMemoryStorage::clear(self::USER_STORAGE_TYPE);
@@ -129,10 +106,7 @@ class InMemoryUserReadModelRepositoryTest extends UserBaseTestCase
         self::assertEquals([], $users);
     }
 
-    /**
-     * @return array
-     */
-    public function getQueryContextDataProvider(): array
+    public static function getQueryContextDataProvider(): array
     {
         return [
             [
@@ -191,9 +165,6 @@ class InMemoryUserReadModelRepositoryTest extends UserBaseTestCase
         ];
     }
 
-    /**
-     * Setup fixtures
-     */
     protected function setUp(): void
     {
         InMemoryStorage::clear();

--- a/tests/Unit/Infrastructure/User/InMemoryUserRepositoryTest.php
+++ b/tests/Unit/Infrastructure/User/InMemoryUserRepositoryTest.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\Tests\Unit\Infrastructure\User;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\Attributes\Test;
 use TSwiackiewicz\AwesomeApp\DomainModel\User\{
     Exception\UserNotFoundException, Password\UserPassword, User, UserLogin
 };
@@ -13,23 +16,13 @@ use TSwiackiewicz\AwesomeApp\SharedKernel\User\Exception\UserRepositoryException
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\UserId;
 use TSwiackiewicz\AwesomeApp\Tests\Unit\UserBaseTestCase;
 
-/**
- * Class InMemoryUserRepositoryTest
- * @package TSwiackiewicz\AwesomeApp\Tests\Unit\Infrastructure\User
- *
- * @@coversDefaultClass InMemoryUserRepository
- * @runTestsInSeparateProcesses
- */
+#[CoversClass(InMemoryUserRepository::class)]
+#[RunTestsInSeparateProcesses]
 class InMemoryUserRepositoryTest extends UserBaseTestCase
 {
-    /**
-     * @var InMemoryUserRepository
-     */
-    private $repository;
+    private InMemoryUserRepository $repository;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldReturnNextIdentity(): void
     {
         $userId = $this->repository->nextIdentity();
@@ -37,25 +30,19 @@ class InMemoryUserRepositoryTest extends UserBaseTestCase
         self::assertInstanceOf(UserId::class, $userId);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldReturnTrueWhenUserExists(): void
     {
         self::assertTrue($this->repository->exists($this->login));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldReturnFalseWhenUserNotExists(): void
     {
         self::assertFalse($this->repository->exists('non_existent_user'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldReturnUserById(): void
     {
         $this->clearIdentityMap();
@@ -67,19 +54,13 @@ class InMemoryUserRepositoryTest extends UserBaseTestCase
         self::assertInstanceOf(User::class, $user);
     }
 
-    /**
-     * Clear identity map
-     */
     private function clearIdentityMap(): void
     {
         $identityMap = new \ReflectionProperty(InMemoryUserRepository::class, 'identityMap');
-        $identityMap->setAccessible(true);
         $identityMap->setValue(null, []);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFetchUserByIdFromStorageOnlyOnce(): void
     {
         $firstAttemptUser = $this->repository->getById(
@@ -94,9 +75,7 @@ class InMemoryUserRepositoryTest extends UserBaseTestCase
         self::assertSame($firstAttemptUser, $secondAttemptUser);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenInvalidStorageDataForUserById(): void
     {
         $this->clearIdentityMap();
@@ -120,9 +99,7 @@ class InMemoryUserRepositoryTest extends UserBaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenUserByIdNotFound(): void
     {
         $this->expectException(UserNotFoundException::class);
@@ -132,9 +109,7 @@ class InMemoryUserRepositoryTest extends UserBaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldReturnUserByHash(): void
     {
         $user = $this->repository->getByHash($this->hash);
@@ -142,9 +117,7 @@ class InMemoryUserRepositoryTest extends UserBaseTestCase
         self::assertInstanceOf(User::class, $user);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenInvalidStorageDataForUserByHash(): void
     {
         $this->clearIdentityMap();
@@ -166,9 +139,7 @@ class InMemoryUserRepositoryTest extends UserBaseTestCase
         $this->repository->getByHash($this->hash);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhenUserByHashNotFound(): void
     {
         $this->expectException(UserNotFoundException::class);
@@ -176,9 +147,7 @@ class InMemoryUserRepositoryTest extends UserBaseTestCase
         $this->repository->getByHash('not_found_user_hash');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldSaveUser(): void
     {
         $user = new User(
@@ -193,9 +162,7 @@ class InMemoryUserRepositoryTest extends UserBaseTestCase
         self::assertTrue($this->repository->getById(UserId::fromInt(1))->isActive());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldSaveUserWithNullId(): void
     {
         InMemoryStorage::nextIdentity(InMemoryStorage::TYPE_USER);
@@ -212,9 +179,7 @@ class InMemoryUserRepositoryTest extends UserBaseTestCase
         self::assertTrue($this->repository->getById($userId)->isActive());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldRemoveUserById(): void
     {
         self::assertEquals(
@@ -231,9 +196,6 @@ class InMemoryUserRepositoryTest extends UserBaseTestCase
         }
     }
 
-    /**
-     * Setup fixtures
-     */
     protected function setUp(): void
     {
         InMemoryStorage::clear();

--- a/tests/Unit/ReadModel/User/UserReadModelTest.php
+++ b/tests/Unit/ReadModel/User/UserReadModelTest.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\Tests\Unit\ReadModel\User;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use TSwiackiewicz\AwesomeApp\Infrastructure\InMemoryStorage;
 use TSwiackiewicz\AwesomeApp\Infrastructure\User\InMemoryUserReadModelRepository;
 use TSwiackiewicz\AwesomeApp\ReadModel\User\UserQuery;
@@ -10,22 +12,12 @@ use TSwiackiewicz\AwesomeApp\ReadModel\User\UserReadModel;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\UserId;
 use TSwiackiewicz\AwesomeApp\Tests\Unit\UserBaseTestCase;
 
-/**
- * Class UserReadModelTest
- * @package TSwiackiewicz\AwesomeApp\Tests\Unit\ReadModel\User
- *
- * @coversDefaultClass UserReadModel
- */
+#[CoversClass(UserReadModel::class)]
 class UserReadModelTest extends UserBaseTestCase
 {
-    /**
-     * @var UserReadModel
-     */
-    private $readModel;
+    private UserReadModel $readModel;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFindUserById(): void
     {
         $userDTO = $this->readModel->findById(UserId::fromInt(1));
@@ -37,9 +29,7 @@ class UserReadModelTest extends UserBaseTestCase
         self::assertEquals(true, $userDTO->isEnabled());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldReturnNullWhenUnableToFindUserById(): void
     {
         $userDTO = $this->readModel->findById(UserId::fromInt(123));
@@ -47,9 +37,7 @@ class UserReadModelTest extends UserBaseTestCase
         self::assertNull($userDTO);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFindUsersByQuery(): void
     {
         $userDTOCollection = $this->readModel->findByQuery(new UserQuery(true, true));
@@ -70,9 +58,7 @@ class UserReadModelTest extends UserBaseTestCase
         self::assertCount(2, $userDTOCollection->getItems());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldReturnEmptyArrayWhenUnableToFindUsersByQuery(): void
     {
         $userDTOCollection = $this->readModel->findByQuery(new UserQuery(true, false));
@@ -80,9 +66,7 @@ class UserReadModelTest extends UserBaseTestCase
         self::assertEquals([], $userDTOCollection->getItems());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldReturnAllUsers(): void
     {
         $userDTOCollection = $this->readModel->getUsers();
@@ -90,9 +74,7 @@ class UserReadModelTest extends UserBaseTestCase
         self::assertCount(3, $userDTOCollection->getItems());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldReturnEmptyArrayWhenNoUsersDefined(): void
     {
         InMemoryStorage::clear();
@@ -102,9 +84,6 @@ class UserReadModelTest extends UserBaseTestCase
         self::assertEquals([], $userDTOCollection);
     }
 
-    /**
-     * Setup fixtures
-     */
     protected function setUp(): void
     {
         InMemoryStorage::clear();

--- a/tests/Unit/SharedKernel/User/UserIdTest.php
+++ b/tests/Unit/SharedKernel/User/UserIdTest.php
@@ -3,21 +3,16 @@ declare(strict_types=1);
 
 namespace TSwiackiewicz\AwesomeApp\Tests\Unit\SharedKernel\User;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\Exception\InvalidArgumentException;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\UserId;
 use TSwiackiewicz\AwesomeApp\Tests\Unit\UserBaseTestCase;
 
-/**
- * Class UserIdTest
- * @package TSwiackiewicz\AwesomeApp\Tests\Unit\SharedKernel\User
- *
- * @coversDefaultClass UserId
- */
+#[CoversClass(UserId::class)]
 class UserIdTest extends UserBaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldCreateFromInt(): void
     {
         $userId = UserId::fromInt($this->userId);
@@ -27,9 +22,7 @@ class UserIdTest extends UserBaseTestCase
         self::assertEquals($this->userId, $userId->getId());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldCreateNullInstance(): void
     {
         $userId = UserId::nullInstance();
@@ -38,9 +31,7 @@ class UserIdTest extends UserBaseTestCase
         self::assertTrue($userId->isNull());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailWhileCreationInvalidUserId(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Unit/UserBaseTestCase.php
+++ b/tests/Unit/UserBaseTestCase.php
@@ -10,77 +10,36 @@ use TSwiackiewicz\AwesomeApp\DomainModel\User\UserLogin;
 use TSwiackiewicz\AwesomeApp\DomainModel\User\UserNotifier;
 use TSwiackiewicz\AwesomeApp\SharedKernel\User\UserId;
 
-/**
- * Class UserBaseTestCase
- * @package TSwiackiewicz\AwesomeApp\Tests\Unit
- */
 abstract class UserBaseTestCase extends TestCase
 {
-    /**
-     * @var int
-     */
-    protected $userId = 1;
+    protected int $userId = 1;
 
-    /**
-     * @var string
-     */
-    protected $login = 'test@domain.com';
+    protected string $login = 'test@domain.com';
 
-    /**
-     * @var string
-     */
-    protected $password = 'password1234';
+    protected string $password = 'password1234';
 
-    /**
-     * @var string
-     */
-    protected $hash = '94b3e2c871ff1b3e4e03c74cd9c501f5';
+    protected string $hash = '94b3e2c871ff1b3e4e03c74cd9c501f5';
 
-    /**
-     * @return array
-     */
-    public function getInvalidLoginDataProvider(): array
+    public static function getInvalidLoginDataProvider(): array
     {
         return [
-            [
-                ''
-            ],
-            [
-                'test'
-            ],
-            [
-                'test@'
-            ],
-            [
-                '@test'
-            ],
-            [
-                'test@domain'
-            ],
-            [
-                'test@domain.'
-            ]
+            [''],
+            ['test'],
+            ['test@'],
+            ['@test'],
+            ['test@domain'],
+            ['test@domain.']
         ];
     }
 
-    /**
-     * @return array
-     */
-    public function getInvalidPasswordDataProvider(): array
+    public static function getInvalidPasswordDataProvider(): array
     {
         return [
-            [
-                ''
-            ],
-            [
-                'test123'
-            ]
+            [''],
+            ['test123']
         ];
     }
 
-    /**
-     * @return User
-     */
     protected function createActiveUser(): User
     {
         return new User(
@@ -92,9 +51,6 @@ abstract class UserBaseTestCase extends TestCase
         );
     }
 
-    /**
-     * @return User
-     */
     protected function createInactiveUser(): User
     {
         return new User(
@@ -106,9 +62,6 @@ abstract class UserBaseTestCase extends TestCase
         );
     }
 
-    /**
-     * @return User
-     */
     protected function createEnabledUser(): User
     {
         return new User(
@@ -120,9 +73,6 @@ abstract class UserBaseTestCase extends TestCase
         );
     }
 
-    /**
-     * @return User
-     */
     protected function createDisabledUser(): User
     {
         return new User(
@@ -134,18 +84,11 @@ abstract class UserBaseTestCase extends TestCase
         );
     }
 
-    /**
-     * @param null|string $eventName
-     * @return UserNotifier|\PHPUnit_Framework_MockObject_MockObject
-     */
     protected function getUserNotifierMock(?string $eventName = null): UserNotifier
     {
-        /** @var UserNotifier|\PHPUnit_Framework_MockObject_MockObject $notifier */
         $notifier = $this->getMockBuilder(UserNotifier::class)
             ->disableOriginalConstructor()
-            ->setMethods([
-                'notifyUser'
-            ])
+            ->onlyMethods(['notifyUser'])
             ->getMock();
         if ($eventName !== null) {
             $notifier->expects(self::once())


### PR DESCRIPTION
## Summary
- Bump PHP requirement from \`>=7.1\` to \`^8.4\`, PHPUnit from \`^6.1\` to \`^11.0\`
- Update \`.travis.yml\` to test on PHP 8.2, 8.3, 8.4
- Refactor all tests to PHP 8 attributes (\`#[Test]\`, \`#[DataProvider]\`, \`#[CoversClass]\`), \`onlyMethods()\`, \`createMock()\`, static data providers
- Refactor source code: constructor property promotion, \`readonly\` properties, native type declarations, remove PHPDoc \`@var\`/\`@param\`/\`@return\`
- Add \`CLAUDE.md\` with project documentation

## Test plan
- [x] 97 tests, 172 assertions — 0 failures, 0 warnings, 0 deprecations
- [x] \`vendor/bin/phpunit --testsuite unit\` passes
- [x] \`vendor/bin/phpunit --testsuite integration\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)