### PR TITLE
Update LICENSE copyright year to 2017-2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Tomasz Świacko-Świackiewicz
+Copyright (c) 2017-2026 Tomasz Świacko-Świackiewicz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

- Update copyright year in `LICENSE` from `2017` to `2017-2026` to reflect the full active development period of the project

## Test plan

- [x] Single-line change in `LICENSE` — no code affected, no tests required

🤖 Generated with [Claude Code](https://claude.com/claude-code)