### PR TITLE
Fix GHSA-qrr6-mg7r-m243: upgrade PHPUnit to ^12.5.22

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,6 @@
         "php": "^8.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11.0"
+        "phpunit/phpunit": "^12.5.22"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,10 +2,7 @@
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         backupGlobals="false"
          colors="true"
-         processIsolation="false"
-         stopOnFailure="false"
          bootstrap="./tests/bootstrap.php"
          failOnWarning="true"
          failOnDeprecation="true"

--- a/tests/Application/User/Handler/UserHandlerBaseTestCase.php
+++ b/tests/Application/User/Handler/UserHandlerBaseTestCase.php
@@ -56,7 +56,7 @@ abstract class UserHandlerBaseTestCase extends UserBaseTestCase
 
     protected function getUserRepositoryMock(): UserRepository
     {
-        return $this->createMock(UserRepository::class);
+        return $this->createStub(UserRepository::class);
     }
 
     protected function getUserRepositoryMockReturningUser(?User $user = null): UserRepository
@@ -90,7 +90,7 @@ abstract class UserHandlerBaseTestCase extends UserBaseTestCase
 
     protected function getUserPasswordServiceMock(): UserPasswordService
     {
-        return $this->createMock(UserPasswordService::class);
+        return $this->createStub(UserPasswordService::class);
     }
 
     protected function getUserPasswordServiceMockForWeakPasswordVerification(): UserPasswordService

--- a/tests/UserBaseTestCase.php
+++ b/tests/UserBaseTestCase.php
@@ -83,15 +83,17 @@ abstract class UserBaseTestCase extends TestCase
 
     protected function getUserNotifierMock(?string $eventName = null): UserNotifier
     {
+        if ($eventName === null) {
+            return $this->createStub(UserNotifier::class);
+        }
+
         $notifier = $this->getMockBuilder(UserNotifier::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['notifyUser'])
             ->getMock();
-        if ($eventName !== null) {
-            $notifier->expects(self::once())
-                ->method('notifyUser')
-                ->with(self::isInstanceOf($eventName));
-        }
+        $notifier->expects(self::once())
+            ->method('notifyUser')
+            ->with(self::isInstanceOf($eventName));
 
         return $notifier;
     }


### PR DESCRIPTION
## Summary

- Upgrades `phpunit/phpunit` from `^11.0` (11.5.55) to `^12.5.22` (resolved: 12.5.23) to address [GHSA-qrr6-mg7r-m243](https://github.com/advisories/GHSA-qrr6-mg7r-m243)
- Removes three `phpunit.xml` attributes dropped from the PHPUnit 12 XSD (`backupGlobals`, `processIsolation`, `stopOnFailure`)
- Replaces `createMock()` with `createStub()` where no expectations are set (PHPUnit 12 emits a notice for mocks without expectations)

## Vulnerability

**GHSA-qrr6-mg7r-m243** — PHPUnit argument injection (CVSS 7.8 High)

`PHPUnit\Util\PHP\JobRunner::settingsToParameters()` passed PHP INI settings to child processes as command-line arguments without neutralizing newline metacharacters. An attacker controlling an INI value could inject arbitrary directives and potentially achieve RCE via `auto_prepend_file` (Poisoned Pipeline Execution via a malicious `phpunit.xml` in a PR).

This project is directly exposed: `InMemoryUserRepositoryTest` uses `#[RunTestsInSeparateProcesses]`, which triggers `settingsToParameters()` on every test in that class.

Patched versions: 12.5.22, 13.1.6.

## Changes

| File | Change |
|------|--------|
| `composer.json` | `^11.0` → `^12.5.22` |
| `phpunit.xml` | Remove `backupGlobals`, `processIsolation`, `stopOnFailure` (removed from PHPUnit 12 XSD) |
| `tests/UserBaseTestCase.php` | `getUserNotifierMock()` — early return `createStub()` when no expectations needed |
| `tests/Application/User/Handler/UserHandlerBaseTestCase.php` | `getUserRepositoryMock()`, `getUserPasswordServiceMock()` — `createMock()` → `createStub()` |

## Test plan

- [ ] `vendor/bin/phpunit` — all 97 tests pass, 0 failures, 0 notices
- [ ] `vendor/bin/phpunit --testsuite infrastructure` — passes (covers the `#[RunTestsInSeparateProcesses]` path that was vulnerable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)